### PR TITLE
fix：getUserId传入context指针，返回userID改为uint32

### DIFF
--- a/app/cart/biz/service/add_item.go
+++ b/app/cart/biz/service/add_item.go
@@ -22,7 +22,7 @@ func (s *AddItemService) Run(req *cart.AddItemReq) (resp *cart.AddItemResp, err 
 	if req.Item.Quantity <= 0 {
 		return nil, fmt.Errorf("quantity must be greater than 0")
 	}
-	userId := uint32(utils.GetUserId(s.ctx))
+	userId := utils.GetUserId(&s.ctx)
 
 	// 获取用户的购物车商品
 	ci := query.Q.CartItem

--- a/app/cart/biz/service/edit_cart.go
+++ b/app/cart/biz/service/edit_cart.go
@@ -24,7 +24,7 @@ func (s *EditCartService) Run(req *cart.EditCartReq) (resp *cart.EditCartResp, e
 	// Finish your business logic.
 	// TODO: add transaction
 	ci := query.Q.CartItem
-	userId := uint32(utils.GetUserId(s.ctx))
+	userId := utils.GetUserId(&s.ctx)
 	klog.Warn("userId", userId)
 	for _, ids := range req.Items {
 

--- a/app/cart/biz/service/frontend_get_cart.go
+++ b/app/cart/biz/service/frontend_get_cart.go
@@ -23,7 +23,7 @@ func (s *FrontendGetCartService) Run(req *cart.FrontendGetCartReq) (resp *cart.F
 	// Finish your business logic.
 	cs := GetCartService{s.ctx}
 	cartResp, err := cs.Run(&cart.GetCartReq{
-		UserId: uint32(utils.GetUserId(s.ctx)),
+		UserId: utils.GetUserId(&s.ctx),
 	})
 	if err != nil {
 		return nil, err

--- a/app/file/biz/service/frontend_upload_file.go
+++ b/app/file/biz/service/frontend_upload_file.go
@@ -20,7 +20,7 @@ func (s *FrontendUploadFileService) Run(req *file.FrontendUploadFileReq) (resp *
 	// Finish your business logic.
 
 	u := NewUploadFileService(s.ctx)
-	userId := utils.GetUserId(s.ctx)
+	userId := utils.GetUserId(&s.ctx)
 	resp1, err := u.Run(&file.UploadFileReq{
 		UserId:   uint64(userId),
 		FileName: req.FileName,

--- a/app/order/biz/service/get_order.go
+++ b/app/order/biz/service/get_order.go
@@ -19,7 +19,7 @@ func NewGetOrderService(ctx context.Context) *GetOrderService {
 
 // Run create note info
 func (s *GetOrderService) Run(req *order.GetOrderReq) (resp *order.GetOrderResp, err error) {
-	userId := utils.GetUserId(s.ctx)
+	userId := utils.GetUserId(&s.ctx)
 	resp = new(order.GetOrderResp)
 	o := query.Q.Order
 	oi := query.Q.OrderItem

--- a/app/order/biz/service/list_order.go
+++ b/app/order/biz/service/list_order.go
@@ -19,7 +19,7 @@ func NewListOrderService(ctx context.Context) *ListOrderService {
 
 // Run create note info
 func (s *ListOrderService) Run(req *order.ListOrderReq) (resp *order.ListOrderResp, err error) {
-	//userId := utils.GetUserId(s.ctx)
+	//userId := utils.GetUserId(&s.ctx)
 	userId := 7
 	// Finish your business logic.
 	o := query.Q.Order

--- a/app/order/biz/service/place_order.go
+++ b/app/order/biz/service/place_order.go
@@ -23,7 +23,7 @@ func (s *PlaceOrderService) Run(req *order.PlaceOrderReq) (resp *order.PlaceOrde
 	// Finish your business logic.
 	// TODO: 事务支持
 	// 插入订单
-	userId := utils.GetUserId(s.ctx)
+	userId := utils.GetUserId(&s.ctx)
 	generateUUID, err := uuid.GenerateUUID()
 
 	ord := &model.Order{

--- a/common/utils/headerHelper.go
+++ b/common/utils/headerHelper.go
@@ -2,23 +2,20 @@ package utils
 
 import (
 	"context"
-	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
 	"strconv"
 )
 
-func GetUserId(ctx context.Context) int {
+func GetUserId(ctx *context.Context) uint32 {
 
-	md, ok := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(*ctx)
 
 	if !ok {
 		return 0
 	}
-	if len(md.Get("user-id")) == 0 {
-		klog.Errorf("user-id not found in header")
-		panic("user-id not found in header")
-	}
 	userId, _ := strconv.Atoi(md.Get("user-id")[0])
+	// 继续传
+	*ctx = metadata.AppendToOutgoingContext(*ctx, "user-id", strconv.Itoa(userId))
 
-	return userId
+	return uint32(userId)
 }


### PR DESCRIPTION
1. fix #48
2. ctx传入改为传入ctx地址
3. 通过metadata.AppendToOutgoingContext参数，给ctx的metadata重新赋值，达到续传的效果
4. userId返回值改为更常用的uint32